### PR TITLE
feat(rbac): Add optional cluster-reader ClusterRole aggregating into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `io.giantswarm.application.managed` chart annotation for Backstage visibility.
+- Add optional `cluster-reader` ClusterRole (off by default, enable via `clusterReader.enabled: true`) that aggregates into the built-in `view` ClusterRole and grants read access (`get`/`list`/`watch`) on cluster-scoped resources commonly needed for troubleshooting: nodes, persistentvolumes, storageclasses, CRDs, apiservices, webhook configurations, ingressclasses, priorityclasses, runtimeclasses, and metrics.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `io.giantswarm.application.managed` chart annotation for Backstage visibility.
-- Add optional `cluster-reader` ClusterRole (off by default, enable via `clusterReader.enabled: true`) that aggregates into the built-in `view` ClusterRole and grants read access (`get`/`list`/`watch`) on cluster-scoped resources commonly needed for troubleshooting: nodes, persistentvolumes, storageclasses, CRDs, apiservices, webhook configurations, ingressclasses, priorityclasses, runtimeclasses, and metrics.
+- Add optional `cluster-reader` ClusterRole (off by default, enabled via `clusterReader.enabled: true`) that aggregates into the built-in `view` ClusterRole and grants read access (`get`/`list`/`watch`) on cluster-scoped resources.
 
 ### Changed
 

--- a/helm/rbac-bootstrap/Chart.yaml
+++ b/helm/rbac-bootstrap/Chart.yaml
@@ -9,7 +9,7 @@ description: Helps to set up initial role bindings in a new cluster
 icon: https://s.giantswarm.io/app-icons/rbac-bootstrap/1/light.svg
 engine: gotpl
 home: https://github.com/giantswarm/rbac-bootstrap-app
-version: 0.2.3
+version: 0.3.0
 sources:
   - https://github.com/giantswarm/rbac-bootstrap-app
 maintainers:

--- a/helm/rbac-bootstrap/Chart.yaml
+++ b/helm/rbac-bootstrap/Chart.yaml
@@ -9,7 +9,7 @@ description: Helps to set up initial role bindings in a new cluster
 icon: https://s.giantswarm.io/app-icons/rbac-bootstrap/1/light.svg
 engine: gotpl
 home: https://github.com/giantswarm/rbac-bootstrap-app
-version: 0.3.0
+version: 0.2.3
 sources:
   - https://github.com/giantswarm/rbac-bootstrap-app
 maintainers:

--- a/helm/rbac-bootstrap/templates/clusterrole-cluster-reader.yaml
+++ b/helm/rbac-bootstrap/templates/clusterrole-cluster-reader.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.clusterReader.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-reader
+  labels:
+    {{- include "rbac.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/status
+      - persistentvolumes
+      - componentstatuses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - csinodes
+      - csidrivers
+      - csistoragecapacities
+      - volumeattachments
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingressclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["node.k8s.io"]
+    resources: ["runtimeclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/helm/rbac-bootstrap/values.schema.json
+++ b/helm/rbac-bootstrap/values.schema.json
@@ -3,6 +3,7 @@
     "type": "object",
     "properties": {
         "clusterReader": {
+            "description": " Enable cluster role to read all cluster-wide resources. Extends view role with cluster scope resources too",
             "type": "object",
             "properties": {
                 "enabled": {

--- a/helm/rbac-bootstrap/values.schema.json
+++ b/helm/rbac-bootstrap/values.schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "clusterReader": {
-            "description": " Enable cluster role to read all cluster-wide resources. Extends view role with cluster scope resources too",
+            "description": "Enable cluster role to read all cluster-wide resources. Extends view role with cluster scope resources too",
             "type": "object",
             "properties": {
                 "enabled": {

--- a/helm/rbac-bootstrap/values.schema.json
+++ b/helm/rbac-bootstrap/values.schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "clusterReader": {
-            "description": "Enable cluster role to read all cluster-wide resources. Extends view role with cluster scope resources too",
+            "description": "Enable cluster role to read all cluster-wide resources. Extends view role with cluster-scope resources too. The default value is false",
             "type": "object",
             "properties": {
                 "enabled": {

--- a/helm/rbac-bootstrap/values.schema.json
+++ b/helm/rbac-bootstrap/values.schema.json
@@ -2,6 +2,14 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "clusterReader": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "bindings": {
             "type": "array",
             "items": {

--- a/helm/rbac-bootstrap/values.yaml
+++ b/helm/rbac-bootstrap/values.yaml
@@ -1,7 +1,7 @@
 clusterReader:
   # When true, install a `cluster-reader` ClusterRole that aggregates into the
   # built-in `view` ClusterRole via the `rbac.authorization.k8s.io/aggregate-to-view`
-  #  label and it grants get/list/watch on cluster-scoped resources (nodes, ...)
+  # label and it grants get/list/watch on cluster-scoped resources (nodes, ...)
   enabled: false
 
 # bindings:

--- a/helm/rbac-bootstrap/values.yaml
+++ b/helm/rbac-bootstrap/values.yaml
@@ -1,11 +1,7 @@
 clusterReader:
   # When true, install a `cluster-reader` ClusterRole that aggregates into the
-  # built-in `view` ClusterRole via the
-  # `rbac.authorization.k8s.io/aggregate-to-view` label. It grants get/list/watch
-  # on cluster-scoped resources (nodes, persistentvolumes, storageclasses,
-  # CRDs, apiservices, webhook configurations, ingressclasses, priorityclasses,
-  # runtimeclasses, metrics) so any binding to `view` gains basic
-  # cluster-troubleshooting reads.
+  # built-in `view` ClusterRole via the `rbac.authorization.k8s.io/aggregate-to-view`
+  #  label and it grants get/list/watch on cluster-scoped resources (nodes, ...)
   enabled: false
 
 # bindings:

--- a/helm/rbac-bootstrap/values.yaml
+++ b/helm/rbac-bootstrap/values.yaml
@@ -1,4 +1,13 @@
-{}
+clusterReader:
+  # When true, install a `cluster-reader` ClusterRole that aggregates into the
+  # built-in `view` ClusterRole via the
+  # `rbac.authorization.k8s.io/aggregate-to-view` label. It grants get/list/watch
+  # on cluster-scoped resources (nodes, persistentvolumes, storageclasses,
+  # CRDs, apiservices, webhook configurations, ingressclasses, priorityclasses,
+  # runtimeclasses, metrics) so any binding to `view` gains basic
+  # cluster-troubleshooting reads.
+  enabled: false
+
 # bindings:
 #   - role: edit
 #     users:


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C0ALXPMB1PW/p1780299573716949

Adds optional ClusterRole `cluster-reader`, labeled `rbac.authorization.k8s.io/aggregate-to-view: "true"`, gated by `clusterReader.enabled` (default off).
